### PR TITLE
Add REST API and ElevenLabs TTS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,51 @@ Think of it like a printing service for papers. The costs to produce is normally
 
 You can host any of these papers using your preferred podcasting app. The RSS feed was verified using W3C's [Feed Validation Service](https://validator.w3.org/feed/).
 
+## 🚀 REST API
+
+An optional FastAPI server exposes the text-to-speech workflow over HTTP, allowing you to trigger conversions without running the CLI manually.
+
+### Environment
+
+Set the following variables before starting the server:
+
+- `OPENAI_API_KEY` – required for OpenAI text generation and TTS.
+- `BUCKET_NAME` – Google Cloud Storage bucket used by the uploader.
+- `ELEVENLABS_API_KEY` – required when using the ElevenLabs provider.
+- `ELEVENLABS_VOICE_ID` – default voice for ElevenLabs (can also be provided per request).
+
+### Run the server
+
+```bash
+uvicorn api:app --host 0.0.0.0 --port 8000
+```
+
+### Example request
+
+```bash
+curl -X POST http://localhost:8000/generate \
+  -H "Content-Type: application/json" \
+  -d '{
+        "mode": "pdf",
+        "pdf_file": "example.pdf",
+        "start_offset": 0,
+        "end_offset": 0,
+        "provider": "elevenlabs",
+        "elevenlabs_voice_id": "<voice-id>"
+      }'
+```
+
+The response contains the chunk directory, merged MP3 path, and (if enabled) the uploaded object path.
+
+## 🔊 Text-to-Speech Providers
+
+The CLI and API now support both OpenAI and ElevenLabs TTS backends via the `--provider` flag or the `provider` request field.
+
+- **OpenAI** (default): choose voices using `--voice` or allow a random default.
+- **ElevenLabs**: supply a voice ID with `--elevenlabs-voice-id` or set `ELEVENLABS_VOICE_ID`.
+
+Use `--skip-upload` (CLI) or `"upload": false` (API) to bypass the Google Cloud Storage upload step when experimenting locally.
+
 ## 📄 Copyright
 
 ### **Ownership and Rights**

--- a/api.py
+++ b/api.py
@@ -1,0 +1,58 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from typing import Literal, Optional
+
+from main import generate_audio
+
+app = FastAPI(title="arxiv-to-mp3 API")
+
+
+class GenerateRequest(BaseModel):
+    mode: Literal["pdf", "text"]
+    pdf_file: Optional[str] = None
+    start_offset: int = 0
+    end_offset: int = 0
+    text_file: Optional[str] = None
+    text_content: Optional[str] = None
+    voice: Optional[str] = None
+    provider: Literal["openai", "elevenlabs"] = "openai"
+    elevenlabs_voice_id: Optional[str] = None
+    chunk_size: int = 4096
+    base_name: Optional[str] = None
+    upload: bool = True
+
+
+class GenerateResponse(BaseModel):
+    status: Literal["completed"]
+    chunks_directory: str
+    merged_file: str
+    uploaded_path: Optional[str]
+    base_name: str
+
+
+@app.get("/health")
+def health_check() -> dict:
+    return {"status": "ok"}
+
+
+@app.post("/generate", response_model=GenerateResponse)
+def generate_endpoint(request: GenerateRequest) -> GenerateResponse:
+    try:
+        result = generate_audio(
+            request.mode,
+            pdf_file=request.pdf_file,
+            start_offset=request.start_offset,
+            end_offset=request.end_offset,
+            text_file=request.text_file,
+            text_content=request.text_content,
+            voice=request.voice,
+            provider=request.provider,
+            elevenlabs_voice_id=request.elevenlabs_voice_id,
+            chunk_size=request.chunk_size,
+            base_name=request.base_name,
+            upload=request.upload,
+        )
+    except Exception as exc:  # pragma: no cover - runtime exception handling
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return GenerateResponse(status="completed", **result)

--- a/episode.py
+++ b/episode.py
@@ -1,6 +1,6 @@
 import random
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Optional
 import argparse
 import os
 import PyPDF2
@@ -130,20 +130,72 @@ class FileTextSource(TextSource):
 
 
 class TTSConverter:
-    def __init__(self, voice: Voice = None, api_client: OpenAI = None):
-        self.voice = voice or random.choice(DEFAULT_VOICES)
-        self.client = api_client or OpenAI()
+    """Text-to-speech converter supporting multiple providers."""
+
+    def __init__(
+        self,
+        voice: Optional[Voice] = None,
+        api_client: Optional[OpenAI] = None,
+        provider: str = "openai",
+        elevenlabs_voice_id: Optional[str] = None,
+        elevenlabs_model_id: str = "eleven_multilingual_v2",
+    ):
+        self.provider = provider
+        self.instructions = "Speak in a conversational tone, like a podcast."
+
+        if provider == "openai":
+            self.voice = voice or random.choice(DEFAULT_VOICES)
+            self.client = api_client or OpenAI()
+            self.model = "gpt-4o-mini-tts"
+        elif provider == "elevenlabs":
+            api_key = os.getenv("ELEVENLABS_API_KEY")
+            if not api_key:
+                raise ValueError(
+                    "Please set the ELEVENLABS_API_KEY environment variable for ElevenLabs."
+                )
+
+            try:
+                from elevenlabs.client import ElevenLabs
+            except ImportError as exc:  # pragma: no cover - import guard
+                raise ImportError(
+                    "The 'elevenlabs' package is required for ElevenLabs support."
+                ) from exc
+
+            self.client = ElevenLabs(api_key=api_key)
+            self.voice = elevenlabs_voice_id or os.getenv("ELEVENLABS_VOICE_ID")
+            if not self.voice:
+                raise ValueError(
+                    "Provide an ElevenLabs voice ID via the parameter or ELEVENLABS_VOICE_ID."
+                )
+            self.model = elevenlabs_model_id
+        else:
+            raise ValueError(f"Unsupported provider '{provider}'")
 
     def text_to_speech(self, text: str, out_path: Path) -> None:
         try:
-            with self.client.audio.speech.with_streaming_response.create(
-                model="gpt-4o-mini-tts",
-                voice=self.voice,
-                input=text,
-                instructions="Speak in a conversational tone, like a podcast.",
-            ) as response:
-                response.stream_to_file(out_path)
-                print(f"Created {out_path.name}")
+            if self.provider == "openai":
+                with self.client.audio.speech.with_streaming_response.create(
+                    model=self.model,
+                    voice=self.voice,
+                    input=text,
+                    instructions=self.instructions,
+                ) as response:
+                    response.stream_to_file(out_path)
+            else:
+                audio_stream = self.client.text_to_speech.convert(
+                    voice_id=self.voice,
+                    model_id=self.model,
+                    text=text,
+                    optimize_streaming_latency="0",
+                    output_format="mp3_44100_128",
+                )
+                with open(out_path, "wb") as f:
+                    for chunk in audio_stream:
+                        if isinstance(chunk, bytes):
+                            f.write(chunk)
+                        elif hasattr(chunk, "decode"):
+                            f.write(chunk.decode("utf-8").encode("utf-8"))
+            print(f"Created {out_path.name}")
         except Exception as e:
             print(f"Error creating {out_path.name}: {e}")
 
@@ -173,13 +225,54 @@ def parse_args():
     parser = argparse.ArgumentParser(description="Convert PDF or text to MP3")
     subparsers = parser.add_subparsers(dest="mode", required=True)
 
+    common_kwargs = {
+        "provider": {"choices": ["openai", "elevenlabs"], "default": "openai"},
+        "chunk_size": {"type": int, "default": 4096},
+        "base_name": {"help": "Override the output base filename."},
+        "skip_upload": {
+            "action": "store_true",
+            "help": "Skip uploading the merged MP3 to cloud storage.",
+        },
+        "elevenlabs_voice_id": {
+            "help": "Voice ID to use when provider is ElevenLabs.",
+        },
+    }
+
     pdf_parser = subparsers.add_parser("pdf", help="PDF mining mode")
     pdf_parser.add_argument("pdf_file", help="PDF filename in papers/")
     pdf_parser.add_argument("start_offset", type=int, help="Pages to skip at start")
     pdf_parser.add_argument("end_offset", type=int, help="Pages to skip at end")
+    pdf_parser.add_argument("--voice", choices=DEFAULT_VOICES, help="Voice to use")
 
     text_parser = subparsers.add_parser("text", help="Direct text mode")
     text_parser.add_argument("text_file", help="Path to text file")
     text_parser.add_argument("--voice", choices=DEFAULT_VOICES, help="Voice to use")
+
+    for parser in (pdf_parser, text_parser):
+        parser.add_argument(
+            "--provider",
+            choices=common_kwargs["provider"]["choices"],
+            default=common_kwargs["provider"]["default"],
+            help="TTS provider to use.",
+        )
+        parser.add_argument(
+            "--chunk-size",
+            type=common_kwargs["chunk_size"]["type"],
+            default=common_kwargs["chunk_size"]["default"],
+            help="Number of characters per audio chunk.",
+        )
+        parser.add_argument(
+            "--base-name",
+            help=common_kwargs["base_name"]["help"],
+        )
+        parser.add_argument(
+            "--skip-upload",
+            action=common_kwargs["skip_upload"]["action"],
+            help=common_kwargs["skip_upload"]["help"],
+        )
+        parser.add_argument(
+            "--elevenlabs-voice-id",
+            help=common_kwargs["elevenlabs_voice_id"]["help"],
+        )
 
     return parser.parse_args()

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import concurrent.futures
 import subprocess
 import os
 from itertools import repeat
+from typing import Optional
 
 from episode import (
     PDFTextSource,
@@ -14,37 +15,70 @@ from episode import (
 )
 
 BUCKET_NAME = os.getenv("BUCKET_NAME")
-if not BUCKET_NAME:
-    raise ValueError("Please set the BUCKET_NAME environment variable.")
 
 
-def main():
-    args = parse_args()
-
-    if args.mode == "pdf":
-        pdf_path = Path(__file__).parent / "papers" / args.pdf_file
-        source = PDFTextSource(pdf_path, args.start_offset, args.end_offset)
+def generate_audio(
+    mode: str,
+    *,
+    pdf_file: Optional[str] = None,
+    start_offset: int = 0,
+    end_offset: int = 0,
+    text_file: Optional[str] = None,
+    text_content: Optional[str] = None,
+    voice: Optional[str] = None,
+    provider: str = "openai",
+    elevenlabs_voice_id: Optional[str] = None,
+    chunk_size: int = 4096,
+    base_name: Optional[str] = None,
+    upload: bool = True,
+) -> dict:
+    if mode == "pdf":
+        if not pdf_file:
+            raise ValueError("pdf_file is required when mode is 'pdf'.")
+        pdf_path = Path(pdf_file)
+        if not pdf_path.is_absolute():
+            pdf_path = Path(__file__).parent / "papers" / pdf_path
+        source = PDFTextSource(pdf_path, start_offset, end_offset)
         text = source.get_text()
-        base_name = Path(args.pdf_file).stem
+        if base_name is None:
+            base_name = pdf_path.stem
+    elif mode == "text":
+        if text_content is not None:
+            text = text_content
+            if base_name is None and text_file:
+                base_name = Path(text_file).stem
+        else:
+            if not text_file:
+                raise ValueError(
+                    "Provide text_file or text_content when mode is 'text'."
+                )
+            text_path = Path(text_file)
+            if not text_path.is_absolute():
+                text_path = Path(__file__).parent / text_path
+            source = FileTextSource(text_path)
+            text = source.get_text_episode()
+            if base_name is None:
+                base_name = text_path.stem
     else:
-        text_path = Path(args.text_file)
-        source = FileTextSource(text_path)
-        text = source.get_text_episode()
-        base_name = Path(args.text_file).stem
+        raise ValueError("mode must be either 'pdf' or 'text'.")
+
+    if not text:
+        raise ValueError("No text available to convert to speech.")
+
+    if base_name is None:
+        base_name = "episode"
 
     out_dir = Path(__file__).parent / "chunks" / base_name
     out_dir.mkdir(parents=True, exist_ok=True)
     print(f"Output: {out_dir}")
 
-    if not text:
-        print("No text found. Exiting.")
-        return
+    converter = TTSConverter(
+        voice,
+        provider=provider,
+        elevenlabs_voice_id=elevenlabs_voice_id,
+    )
+    print(f"Using provider: {provider}, voice: {voice or converter.voice}")
 
-    voice = getattr(args, "voice", None)
-    converter = TTSConverter(voice)
-    print(f"Using voice: {voice}")
-
-    chunk_size = 4096
     cost_per_char = 15e-6
     total_chars = len(text)
     num_chunks = math.ceil(total_chars / chunk_size)
@@ -69,7 +103,44 @@ def main():
         stderr=subprocess.PIPE,
     )
     merged = Path(__file__).parent / "lib" / f"{base_name}.mp3"
-    Uploader(BUCKET_NAME).upload(merged, f"lib/{base_name}.mp3")
+
+    uploaded_path = None
+    if upload:
+        if not BUCKET_NAME:
+            raise ValueError(
+                "Please set the BUCKET_NAME environment variable before uploading."
+            )
+        uploaded_path = f"lib/{base_name}.mp3"
+        Uploader(BUCKET_NAME).upload(merged, uploaded_path)
+
+    return {
+        "chunks_directory": out_dir.as_posix(),
+        "merged_file": merged.as_posix(),
+        "uploaded_path": uploaded_path,
+        "base_name": base_name,
+    }
+
+
+def main():
+    args = parse_args()
+
+    result = generate_audio(
+        args.mode,
+        pdf_file=getattr(args, "pdf_file", None),
+        start_offset=getattr(args, "start_offset", 0),
+        end_offset=getattr(args, "end_offset", 0),
+        text_file=getattr(args, "text_file", None),
+        voice=getattr(args, "voice", None),
+        provider=getattr(args, "provider", "openai"),
+        elevenlabs_voice_id=getattr(args, "elevenlabs_voice_id", None),
+        chunk_size=getattr(args, "chunk_size", 4096),
+        base_name=getattr(args, "base_name", None),
+        upload=not getattr(args, "skip_upload", False),
+    )
+
+    print("Generation complete:")
+    for key, value in result.items():
+        print(f"  {key}: {value}")
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,5 +12,9 @@ dependencies = [
   "pulumi>=3.162.0",
   "pulumi-gcp>=8.26.0",
   "pypdf2>=3.0.1",
+  "fastapi>=0.115.0",
+  "uvicorn[standard]>=0.30.0",
+  "pydantic>=2.8.0",
+  "elevenlabs>=1.3.0",
   "transformers==4.38.2",
 ]


### PR DESCRIPTION
## Summary
- add a FastAPI server with /generate and /health endpoints for automating audio generation
- extend the text-to-speech pipeline to support both OpenAI and ElevenLabs providers with configurable options
- document the new API and CLI flags and include the necessary dependencies

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_6902467e2e508320b13fa9cc9a627c5b